### PR TITLE
Prevents error when name of object is an NaN

### DIFF
--- a/simplekml/base.py
+++ b/simplekml/base.py
@@ -58,6 +58,7 @@ class Kmlable(object):
                     buf.append(u"{0}".format(val))  # Use the variable's __str__ as is
                 else:
                     if var in ['name', 'description', 'text', 'linkname', 'linkdescription', 'message', 'change', 'create', 'delete', 'link'] and parsetext: # Parse value for HTML and convert
+                        val = str(val) # _chrconvert() barfs with inscrutable error when not passed a string, e.g. a NaN value. 
                         val = Kmlable._chrconvert(val)
                     elif (var == 'href' and os.path.exists(val) and outputkmz == True)\
                             or (var == 'targetHref' and os.path.exists(val) and outputkmz == True): # Check for images


### PR DESCRIPTION
The _chrconvert() function barfs with an inscrutable error when passed a NaN float (and other non-string values). This is an issue when Pandas passes a NaN for a blank value in a column that otherwise holds strings. This cast prevents that particular failure, and additionally allows use of non-string types as object names and descriptions. 




