### PR TITLE
Avoid writing duplicate files into kmz

### DIFF
--- a/simplekml/base.py
+++ b/simplekml/base.py
@@ -62,7 +62,7 @@ class Kmlable(object):
                         val = Kmlable._chrconvert(val)
                     elif (var == 'href' and os.path.exists(val) and outputkmz == True)\
                             or (var == 'targetHref' and os.path.exists(val) and outputkmz == True): # Check for images
-                        Kmlable._currentroot._foundimages.append(val)
+                        Kmlable._currentroot._foundimages.add(val)
                         val = os.path.join('files', os.path.split(val)[1]).replace('\\', '/')
                         val = Kmlable._chrconvert(val)
                     elif (var in ['href', 'targetHref']):

--- a/simplekml/kml.py
+++ b/simplekml/kml.py
@@ -57,8 +57,8 @@ class Kml(Kmlable):
         self._hint = None
         self._parsetext = True
         self._outputkmz = False
-        self._images = []
-        self._foundimages = []
+        self._images = set()
+        self._foundimages = set()
         self._namespaces = ['xmlns="http://www.opengis.net/kml/2.2"', 'xmlns:gx="http://www.google.com/kml/ext/2.2"']
         self._processedstyles = []
         
@@ -87,7 +87,7 @@ class Kml(Kmlable):
 
         *New in version 1.2.0*
         """
-        self._images.append(path)
+        self._images.add(path)
         return os.path.join('files', os.path.split(path)[1]).replace("\\", "/")
 
     @property


### PR DESCRIPTION
This commit addresses the issue that the duplicate files are stored within the KMZ.
This is caused by the followings:
 * a single local file path is used in multiple href tags (then its path is repeatedly appended to Kml._foundimages)
 * a single local file path is multiply appended by Kml.addfile
